### PR TITLE
 CDP-37-integrate-docker-with-jenkins

### DIFF
--- a/terraform/ansible/docker-server.yml
+++ b/terraform/ansible/docker-server.yml
@@ -52,3 +52,10 @@
         name: ec2-user
         groups: docker
         append: yes
+
+    - name: Add user jenkins to docker group
+      user:
+        name: dockeradmin
+        groups: docker
+        password: dockeradmin
+        append: yes


### PR DESCRIPTION
 + dockeradmin user for docker group

 this is the task for integrating jenkins credentials to docker host

tested